### PR TITLE
🐛 fix(home): correct typo in welcome message

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
           Welcome, Trainers !
         </h1>
         <h1 className="text-[2rem] opacity-75 font-normal">
-          Whatcha lookin' for?
+          What are you looking for?
         </h1>
       </div>
       <CardGrid cards={menu}></CardGrid>


### PR DESCRIPTION
- fix "whatcha" to "what are you" in the home page title